### PR TITLE
change ls -h translation

### DIFF
--- a/book/chap04.md
+++ b/book/chap04.md
@@ -193,7 +193,7 @@ ls display its results in ascending alphabetical order.  </td>
 <tr>
 <td >-h</td>
 <td >--human-readable</td>
-<td >以长格式列出。以人们可读的格式，而不是以字节数来显示文件的大小。</td>
+<td >当以长格式列出时，以人们可读的格式，而不是以字节数来显示文件的大小。</td>
 </tr>
 <tr>
 <td >-l</td>


### PR DESCRIPTION
`ls -h` 需要配合 `-l`来使用，只有在以长格式列出的时候，才能显示人类可读的格式。
单独使用`ls -h`是得不到长格式输出的。
