### PR TITLE
修改第8章里面花括号展开中的 may not 翻译

### DIFF
--- a/book/chap08.md
+++ b/book/chap08.md
@@ -323,8 +323,8 @@ comma-separated list of strings, or a range of integers or single characters. Th
 may not contain embedded whitespace. Here is an example using a range of integers:
 
 花括号展开模式可能包含一个开头部分叫做报头，一个结尾部分叫做附言。花括号表达式本身可
-能包含一个由逗号分开的字符串列表，或者一系列整数，或者单个的字符串。这种模式可能
-不包括嵌入的空白。这个例题使用了一系列整数：
+能包含一个由逗号分开的字符串列表，或者一系列整数，或者单个的字符串。这种模式不能
+嵌入空白字符。这个例题使用了一系列整数：
 
     [me@linuxbox ~]$ echo Number_{1..5}
     Number_1  Number_2  Number_3  Number_4  Number_5


### PR DESCRIPTION
个人觉得 may not contain embedded whitespace 理解成不能加入空白字符要比 可能不包含空白字符要合适一些。may 除了有可能的意思，也可以表示可以，在花括号展开中如果括号里面有空白字符，展开将会失败，比如 echo Front-{A, B, C}-Back 输入的是 Front-{A, B, C}-Back 而不是 Front-A-Back Front-B-Back Front-C-Back。
