### PR TITLE
格式上的一些小改动

### DIFF
--- a/book/chap12.md
+++ b/book/chap12.md
@@ -744,7 +744,7 @@ format directory listing.</td>
 <tr>
 <td valign="top" width="25%">alias l.='ls -d .* --color=auto' </td>
 <td
-valign="top">创建一个新命令，叫做'l.'，这个命令会显示所有以点开头的目录名。</td>
+valign="top">创建一个新命令，叫做'l.'，这个命令会显示所有以点开头的目录项。</td>
 </tr>
 <tr>
 <td valign="top" width="25%">alias ll='ls -l --color=auto'

--- a/book/chap12.md
+++ b/book/chap12.md
@@ -17,19 +17,19 @@ shell experience.
 
 In this chapter, we will work with the following commands:
 
-在这一章，我们将用到以下命令：
-
 * printenv – Print part or all of the environment
 
 * set – Set shell options
 
-* alias – Create an alias for a command
-
 * export – Export environment to subsequently executed programs
 
-* set - 设置 shell 选项
+* alias – Create an alias for a command
+
+在这一章，我们将用到以下命令：
 
 * printenv - 打印部分或所有的环境变量
+
+* set - 设置 shell 选项
 
 * export — 导出环境变量，让随后执行的程序知道。
 


### PR DESCRIPTION
我参考了http://linuxcommand.org/tlcl.php中的英文原文，发现这里英文部分的 export 和 alias 命令顺序好像是颠倒了，而中文翻译中的 set 命令和 printevn 命令顺序应该是颠倒了。此外，个人觉得把“In this chapter, we will work with the following commands”这句和下面命令的介绍合在一起作为一段翻译会不会比单独分开翻译要清晰一些，乍一眼看上去英文原文的命令介绍和中文翻译的介绍像是同一个列表（完全是个人感觉，如果有出于其他方面因素的考虑，直接忽略我好了）。
