### PR TITLE
fix compile warning

### DIFF
--- a/tools/makepdf/clean
+++ b/tools/makepdf/clean
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm *.aux *.log *.out *.toc *.tex
+rm -f *.aux *.log *.out *.toc *.tex


### PR DESCRIPTION
using rm -f to supress warning as below:
rm: cannot remove `*.aux': No such file or directory
rm: cannot remove`_.log': No such file or directory
rm: cannot remove `_.out': No such file or directory
rm: cannot remove `*.toc': No such file or directory
