### PR TITLE
添加了一个所需的依赖.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,7 @@
 * makepdf 目录是生成中文 pdf 的工具，首先需要安装 `kramdown`,
 
 ```
+gem install kramdown-parser-gfm
 gem install kramdown
 ```
 Linux下需要安装 texlive-xetex 及相关软件包。 在Ubuntu14.10下：


### PR DESCRIPTION
添加了一个所需的依赖.
原tool/README.MD中缺了所需依赖`kramdown-parser-gfm`的安装步骤, 这会导致使用命令`ruby makepdf.rb en-cn|cn`导出pdf时出现如下错误:
```shell
(base) KNLc@lKNLc-desktop:~/下载/TLCL-gh-pages/tools/makepdf$ ruby makepdf.rb en-cn
/var/lib/gems/2.3.0/gems/kramdown-2.1.0/lib/kramdown/document.rb:104:in `initialize': kramdown has no parser to handle the specified input format: GFM (Kramdown::Error)
	from makepdf.rb:147:in `new'
	from makepdf.rb:147:in `block in <main>'
	from makepdf.rb:138:in `each'
	from makepdf.rb:138:in `<main>'
```

